### PR TITLE
Modify Cancel button style

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,12 +330,12 @@
     }
 
     #cancelPasswordBtn {
-      background-color: #E9ECEF; 
-      color: var(--text-dark);
-      border: 1px solid #DDE2E7;
+      background-color: #ffb3b3; /* pastel red background */
+      color: var(--text-light);
+      border: none;
     }
     #cancelPasswordBtn:hover {
-      background-color: #CFD8DC;
+      background-color: #ff9e9e;
     }
 
     @keyframes shake {


### PR DESCRIPTION
## Summary
- adjust cancel button in password modal to have a pastel red background

## Testing
- `tidy` *(fails: command not found)*
- `htmlhint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b42ec4b00832fa3d428b7efb6f7bf